### PR TITLE
enhance: specify interoperability as system requirement

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -6,6 +6,7 @@
       <Version>1.0.3</Version>
       <Description>A tool which lets you create IRIS Interoperability productions just by connecting building blocks</Description>
       <Packaging>module</Packaging>
+      <SystemRequirements Interoperability="enabled"/>
       <SourcesRoot>src</SourcesRoot>
       <Dependencies>
         <ModuleReference>


### PR DESCRIPTION
Hi there, 

[InterSystems packages manager](https://github.com/intersystems/ipm) allows package contributors to declare their package requires an interoperability-enabled namespace. With this change, a user will get a more descriptive warning:
```
ERROR! This module requires an interoperability-enabled namespace. USER is not interoperability-enabled.
```
when trying to install the package on namespaces without interoperability.